### PR TITLE
Adding code to default to speaker

### DIFF
--- a/PitchPerfect/PlaySoundsViewController.swift
+++ b/PitchPerfect/PlaySoundsViewController.swift
@@ -11,6 +11,7 @@ import AVFoundation
 
 class PlaySoundsViewController: UIViewController {
     
+    var session: AVAudioSession!
     var audioPlayer:AVAudioPlayer!
     var echoPlayer:AVAudioPlayer!
     var receivedAudio:RecordedAudio!
@@ -21,6 +22,8 @@ class PlaySoundsViewController: UIViewController {
     override func viewDidLoad() {
 
         super.viewDidLoad()
+        session = AVAudioSession.sharedInstance()
+        try! session.setCategory(AVAudioSessionCategoryPlayAndRecord, withOptions: .DefaultToSpeaker)
         audioPlayer = try! AVAudioPlayer(contentsOfURL: receivedAudio.filePathUrl)
         echoPlayer = try! AVAudioPlayer(contentsOfURL: receivedAudio.filePathUrl)
         audioPlayer.enableRate = true


### PR DESCRIPTION
When testing on an actual device, it would default to the phone receiver (i.e., not very audible.)  This code switches the default to use the speaker.  You may want to handle the try case instead of relying on the forced try.
